### PR TITLE
Support also InjectManifest override

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,17 @@ module.exports = {
 ```
 // workbox.config.js
 
-module.exports = options => {
-  options.skipWaiting = true;
-  return options;
+module.exports = {
+  GenerateSW: options => {
+    // override GenerateSW config here
+    // e.g. options.skipWaiting = true;
+    return options;
+  },
+  InjectManifest: options => {
+    // override InjectManifest config here
+    // e.g. options.maximumFileSizeToCacheInBytes = 10 * 1024 * 1024;
+    return options;
+  }
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install craco-workbox -S
 
 1. Add the plugin into your craco.config.js;
 
-```
+```javascript
 // craco.config.js
 
 const CracoWorkboxPlugin = require('craco-workbox');
@@ -32,7 +32,7 @@ module.exports = {
 
 2. Add a workbox.config.js file to your project root containing the overrides you would like to pass. For a full list of options see [https://developers.google.com/web/tools/workbox/modules/workbox-webpack-plugin#generatesw_plugin](https://developers.google.com/web/tools/workbox/modules/workbox-webpack-plugin#generatesw_plugin).
 
-```
+```javascript
 // workbox.config.js
 
 module.exports = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,11 @@ module.exports = {
 
         webpackConfig.plugins.forEach(plugin => {
           if (plugin.constructor.name === "GenerateSW") {
-            plugin.config = workboxConfig(plugin.config);
+            plugin.config = workboxConfig.GenerateSW(plugin.config);
+          }
+
+          if (plugin.constructor.name === "InjectManifest") {
+            plugin.config = workboxConfig.InjectManifest(plugin.config);
           }
         });
       } catch (error) {


### PR DESCRIPTION
With this PR I wanted to add the possibility to override also `InjectManifest` config (not also `GenerateSW`).


This should respond to this issue -> #2 

I just added a control for the existence of the InjectManifest constructor (as @kevinsperrine suggested) and injected the proprer config object.
The `workbox.config.js` fie should now look like this:

```javascript
// workbox.config.js

module.exports = {
  GenerateSW: options => {
    // override GenerateSW config here
    // e.g. options.skipWaiting = true;
    return options;
  },
  InjectManifest: options => {
    // override InjectManifest config here
    // e.g. options.maximumFileSizeToCacheInBytes = 10 * 1024 * 1024;
    return options;
  }
};
```

(I also updated the README)

I tested it in a project I'm working to, and seems to work just fine! ;)
